### PR TITLE
Adds the harbor project to image tags

### DIFF
--- a/k8s/musicstore.yml
+++ b/k8s/musicstore.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: musicservice
-        image: #@ "{}/music-service:latest".format(data.values.registry.host)
+        image: #@ "{}/{}/music-service:latest".format(data.values.registry.host, data.values.project)
         ports:
         - containerPort: 80
         env:
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: orderservice
-        image: #@ "{}/order-service:latest".format(data.values.registry.host)
+        image: #@ "{}/{}/order-service:latest".format(data.values.registry.host, data.values.project)
         ports:
         - containerPort: 80
         env:
@@ -95,7 +95,7 @@ spec:
     spec:
       containers:
       - name: shoppingcartservice
-        image: #@ "{}/cart-service:latest".format(data.values.registry.host)
+        image: #@ "{}/{}/cart-service:latest".format(data.values.registry.host, data.values.project)
         ports:
         - containerPort: 80
         env:
@@ -134,7 +134,7 @@ spec:
     spec:
       containers:
       - name: musicstore
-        image: #@ "{}/ui:latest".format(data.values.registry.host)
+        image: #@ "{}/{}/ui:latest".format(data.values.registry.host, data.values.project)
         ports:
         - containerPort: 80
         env:


### PR DESCRIPTION
TL;DR
-----

Inserst the Harbor project name into the image tags so they'll
be found correctly

Details
-------

Fixes the previous update for the image tags to make sure the tag
includes the project as well as the host.