### PR TITLE
Uses downward API to get namespace

### DIFF
--- a/k8s/musicstore.yml
+++ b/k8s/musicstore.yml
@@ -83,6 +83,10 @@ spec:
             value: "8080"
           - name: eureka__instance__hostName
             value: "musicservice"
+          - name: spring__kubernetes__namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: eurekaclient
@@ -113,6 +117,10 @@ spec:
         env:
           - name: INIT
             value: "true"
+          - name: spring__kubernetes__namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: eurekaclient
@@ -157,6 +165,10 @@ spec:
             value: "8080"
           - name: eureka__instance__hostName
             value: "orderservice"
+          - name: spring__kubernetes__namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: eurekaclient
@@ -187,6 +199,10 @@ spec:
         env:
           - name: INIT
             value: "true"
+          - name: spring__kubernetes__namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: eurekaclient
@@ -231,6 +247,10 @@ spec:
             value: "8080"
           - name: eureka__instance__hostName
             value: "shoppingcartservice"
+          - name: spring__kubernetes__namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: eurekaclient
@@ -261,6 +281,10 @@ spec:
         env:
           - name: INIT
             value: "true"
+          - name: spring__kubernetes__namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: eurekaclient
@@ -305,6 +329,10 @@ spec:
             value: "8080"
           - name: eureka__instance__hostName
             value: "musicstore"
+          - name: spring__kubernetes__namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: eurekaclient
@@ -335,6 +363,10 @@ spec:
         env:
           - name: INIT
             value: "true"
+          - name: spring__kubernetes__namespace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         envFrom:
           - configMapRef:
               name: eurekaclient


### PR DESCRIPTION
TL;DR
-----

Sets the namespace for Spring Cloud Kubernetes using downward API

Details
-------

Avoids hardcoding in the source code by setting the namespace for
Spring Cloud Kubernetes using the Downward API.